### PR TITLE
Safely access Session ID header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.3.0
+  - 2.4.0
 services:
   - redis
   - postgres

--- a/bank_routing.gemspec
+++ b/bank_routing.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 	gem.add_development_dependency 'redis'
 	gem.add_development_dependency 'pg'
 
-	gem.add_dependency 'typhoeus', '~> 0.6'
+	gem.add_dependency 'typhoeus', '~> 1.0'
 	gem.add_dependency 'yajl-ruby', '~> 1.2'
 
 end

--- a/lib/bank_routing/http_adapter.rb
+++ b/lib/bank_routing/http_adapter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'typhoeus'
+
+class RoutingNumber
+  class HttpAdapter
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
+    def fetch_routing_directory
+      response = Typhoeus::Request.post(
+        options[:routing_data_agreement_url],
+        body: 'agreementValue=Agree'
+      )
+      session_id = response.headers['Set-Cookie']&.match(/JSESSIONID=.*?;/)
+
+      if session_id
+        Typhoeus::Request.get(
+          options[:routing_data_url],
+          ssl_verifypeer: false,
+          headers: { 'Cookie' => session_id.to_s }
+        ).body
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Avoid nil object exceptions when the initial request for accepting the ToS fails, such as in the case of a timeout.
- Update Typhoeus